### PR TITLE
Add minikube example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ You can install Kubernetes on your laptop with minikube: https://github.com/kube
 
 Or, you can use Google Container Engine's free trial to get a 3 node cluster.
 
-
 ### Verify access to the cluster
 
 ```
@@ -91,18 +90,45 @@ Or, you can use Google Container Engine's free trial to get a 3 node cluster.
 
 ### Get and Run Fission
 
-If you're using GKE, use the fission.yaml unmodified.  If you're using
-minikube, change all instances of LoadBalancer services to NodePort.
+Deploy the fission services and deployments.
 
 ```
-  $ kubectl create -f http://fission.io/fission.yaml 
+  $ kubectl create -f http://fission.io/fission.yaml
+```
+
+#### local and no cloud provider
+
+If you're using minikube or no cloud provider use the services with NodePort.
+
+```
+  $ kubectl create -f http://fission.io/fission-nodeport.yaml
+```
+
+#### Cloud
+
+If you're using GKE or any other cloud provider, use the services with a LoadBalancer.
+
+```
+  $ kubectl create -f http://fission.io/fission-cloud.yaml
+```
+
+### Set fission URLs
+
+```
   $ kubectl --namespace fission get services
 ```
 
 Save the external IP addresses of controller and router services in
 FISSION_URL and FISSION_ROUTER, respectively.  FISSION_URL is used by
 the fission CLI to find the server.  (FISSION_ROUTER is only needed
-for the examples below to work.)
+for the examples below to work.) Below is an example
+for Minikube with NodePort.
+
+```
+  $ export FISSION_ROUTER=$(minikube ip):31314
+
+  $ export FISSION_URL=http://$(minikube ip):31313
+```
 
 ### Install the client CLI
 
@@ -118,7 +144,7 @@ for the examples below to work.)
 
 ```
   $ fission env create --name nodejs --image fission/node-env
-  
+
   $ echo 'module.exports = function(context, callback) { callback(200, "Hello, world!\n"); }' > hello.js  
 
   $ fission function create --name hello --env nodejs --code hello.js

--- a/fission-cloud.yaml
+++ b/fission-cloud.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: router
+  namespace: fission
+  labels:
+    svc: router
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 8888
+    nodePort: 31314
+  selector:
+    svc: router
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: controller
+  namespace: fission
+  labels:
+    svc: controller
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 8888
+    nodePort: 31313
+  selector:
+    svc: controller

--- a/fission-nodeport.yaml
+++ b/fission-nodeport.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: router
+  namespace: fission
+  labels:
+    svc: router
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 8888
+    nodePort: 31314
+  selector:
+    svc: router
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: controller
+  namespace: fission
+  labels:
+    svc: controller
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 8888
+    nodePort: 31313
+  selector:
+    svc: controller

--- a/fission.yaml
+++ b/fission.yaml
@@ -14,23 +14,6 @@ metadata:
     name: fission-function
 
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: controller
-  namespace: fission
-  labels:
-    svc: controller
-spec:
-  type: LoadBalancer
-  ports:
-  - port: 80
-    targetPort: 8888
-    nodePort: 31313
-  selector:
-    svc: controller
-
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -48,23 +31,6 @@ spec:
         image: fission/fission-bundle:alpha
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888", "--filepath", "/filestore"]
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: router
-  namespace: fission
-  labels:
-    svc: router
-spec:
-  type: LoadBalancer
-  ports:
-  - port: 80
-    targetPort: 8888
-    nodePort: 31314
-  selector:
-    svc: router
 
 ---
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
I tried to update the Readme to make it a little bit easier to start with `fission` on minikube.