### PR TITLE
Updated README to include protocol scheme for FISSION_URL prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ minikube, change all instances of LoadBalancer services to NodePort.
 ```
 
 Save the external IP addresses of controller and router services in
-FISSION_URL and FISSION_ROUTER, respectively.  FISSION_URL is used by
+FISSION_URL and FISSION_ROUTER, respectively. FISSION_URL should be prefixed with a `http://`.  FISSION_URL is used by
 the fission CLI to find the server.  (FISSION_ROUTER is only needed
 for the examples below to work.)
 


### PR DESCRIPTION
Hey 👋 

I was going through the README to test this out and noticed that if you don't prefix the FISSION_URL with http:// you get the following error:

```
Failed to create environment: Post xxx.xxx.xxx.xxx/v1/environments: unsupported protocol scheme ""
```

I've added a bit on the README to prompt for this.

Hope this is ok.

Thanks,
Ville

ps. Awesome project! I'll definitely be playing around with this more soon! The cold start response time over what the AWS API Gateway latency is makes this very feasible!