### PR TITLE
Fix cache test

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -27,11 +27,11 @@ func checkErr(err error) {
 }
 
 func TestCache(t *testing.T) {
-	c := MakeCache(100 * time.Millisecond)
+	c := MakeCache(100*time.Millisecond, 100*time.Millisecond)
 
-	err := c.Set("a", "b")
+	err, _ := c.Set("a", "b")
 	checkErr(err)
-	err = c.Set("p", "q")
+	err, _ = c.Set("p", "q")
 	checkErr(err)
 
 	val, err := c.Get("a")
@@ -53,7 +53,7 @@ func TestCache(t *testing.T) {
 		log.Panicf("found deleted element")
 	}
 
-	err = c.Set("expires", "42")
+	err, _ = c.Set("expires", "42")
 	checkErr(err)
 	time.Sleep(150 * time.Millisecond)
 	_, err = c.Get("expires")


### PR DESCRIPTION
cache.Set() returns existing value; update the test accordingly.